### PR TITLE
Upgrade Elementary Audio

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,8 +8,8 @@
       "name": "coincident-spectra",
       "version": "0.1.0",
       "dependencies": {
-        "@elemaudio/core": "^1.0.5",
-        "@elemaudio/web-renderer-lite": "^1.0.0",
+        "@elemaudio/core": "^1.0.8",
+        "@elemaudio/web-renderer": "^1.0.16",
         "rxjs": "^7.5.4"
       },
       "devDependencies": {
@@ -24,7 +24,6 @@
         "eslint": "^7.32.0",
         "eslint-config-prettier": "^8.1.0",
         "eslint-plugin-svelte3": "^3.2.1",
-        "one-webcrypto": "^1.0.1",
         "prettier": "~2.2.1",
         "prettier-plugin-svelte": "^2.2.0",
         "rehype-autolink-headings": "^6.1.0",
@@ -196,13 +195,14 @@
         "shallowequal": "^1.1.0"
       }
     },
-    "node_modules/@elemaudio/web-renderer-lite": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@elemaudio/web-renderer-lite/-/web-renderer-lite-1.0.0.tgz",
-      "integrity": "sha512-yvXD2TWOEdHz5P1fE5dJqR7dgQ7RQVa1a7+9N5eTRTrVe2VXIYaDseJf5C56AAZ+cAUPmSI8Mv2X0qGLIiugkw==",
-      "deprecated": "web-renderer-lite is no longer supported, please see @elemaudio/web-renderer",
+    "node_modules/@elemaudio/web-renderer": {
+      "version": "1.0.16",
+      "resolved": "https://registry.npmjs.org/@elemaudio/web-renderer/-/web-renderer-1.0.16.tgz",
+      "integrity": "sha512-uwyk9QMfV4QGndQ78bp3mw4q5jlr8zmGDmEnjQvNiMXHqMSd3p4TBVA/bN/zUifgwk7dRO4P6xdb5jrr4IzF+Q==",
       "dependencies": {
-        "@elemaudio/core": "^1.0.0"
+        "@elemaudio/core": "^1.0.8",
+        "@types/events": "^3.0.0",
+        "events": "^3.3.0"
       }
     },
     "node_modules/@esbuild/android-arm": {
@@ -799,6 +799,11 @@
       "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.5.1.tgz",
       "integrity": "sha512-COUnqfB2+ckwXXSFInsFdOAWQzCCx+a5hq2ruyj+Vjund94RJQd4LG2u9hnvJrTgunKAaax7ancBYlDrNYxA0g==",
       "dev": true
+    },
+    "node_modules/@types/events": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/events/-/events-3.0.0.tgz",
+      "integrity": "sha512-EaObqwIvayI5a8dCzhFrjKzVwKLxjoG9T6Ppd5CEo07LRKfQ8Yokw54r5+Wq7FaBQ+yXRvQAYPrHwya1/UFt9g=="
     },
     "node_modules/@types/hast": {
       "version": "2.3.4",
@@ -2606,6 +2611,14 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/events": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "engines": {
+        "node": ">=0.8.x"
+      }
+    },
     "node_modules/extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
@@ -3933,12 +3946,6 @@
       "dependencies": {
         "wrappy": "1"
       }
-    },
-    "node_modules/one-webcrypto": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/one-webcrypto/-/one-webcrypto-1.0.3.tgz",
-      "integrity": "sha512-fu9ywBVBPx0gS9K0etIROTiCkvI5S1TDjFsYFb3rC1ewFxeOqsbzq7aIMBHsYfrTHBcGXJaONXXjTl8B01cW1Q==",
-      "dev": true
     },
     "node_modules/onetime": {
       "version": "5.1.2",
@@ -6474,12 +6481,14 @@
         "shallowequal": "^1.1.0"
       }
     },
-    "@elemaudio/web-renderer-lite": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@elemaudio/web-renderer-lite/-/web-renderer-lite-1.0.0.tgz",
-      "integrity": "sha512-yvXD2TWOEdHz5P1fE5dJqR7dgQ7RQVa1a7+9N5eTRTrVe2VXIYaDseJf5C56AAZ+cAUPmSI8Mv2X0qGLIiugkw==",
+    "@elemaudio/web-renderer": {
+      "version": "1.0.16",
+      "resolved": "https://registry.npmjs.org/@elemaudio/web-renderer/-/web-renderer-1.0.16.tgz",
+      "integrity": "sha512-uwyk9QMfV4QGndQ78bp3mw4q5jlr8zmGDmEnjQvNiMXHqMSd3p4TBVA/bN/zUifgwk7dRO4P6xdb5jrr4IzF+Q==",
       "requires": {
-        "@elemaudio/core": "^1.0.0"
+        "@elemaudio/core": "^1.0.8",
+        "@types/events": "^3.0.0",
+        "events": "^3.3.0"
       }
     },
     "@esbuild/android-arm": {
@@ -6830,6 +6839,11 @@
       "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.5.1.tgz",
       "integrity": "sha512-COUnqfB2+ckwXXSFInsFdOAWQzCCx+a5hq2ruyj+Vjund94RJQd4LG2u9hnvJrTgunKAaax7ancBYlDrNYxA0g==",
       "dev": true
+    },
+    "@types/events": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/events/-/events-3.0.0.tgz",
+      "integrity": "sha512-EaObqwIvayI5a8dCzhFrjKzVwKLxjoG9T6Ppd5CEo07LRKfQ8Yokw54r5+Wq7FaBQ+yXRvQAYPrHwya1/UFt9g=="
     },
     "@types/hast": {
       "version": "2.3.4",
@@ -8131,6 +8145,11 @@
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
       "dev": true
     },
+    "events": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q=="
+    },
     "extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
@@ -9115,12 +9134,6 @@
       "requires": {
         "wrappy": "1"
       }
-    },
-    "one-webcrypto": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/one-webcrypto/-/one-webcrypto-1.0.3.tgz",
-      "integrity": "sha512-fu9ywBVBPx0gS9K0etIROTiCkvI5S1TDjFsYFb3rC1ewFxeOqsbzq7aIMBHsYfrTHBcGXJaONXXjTl8B01cW1Q==",
-      "dev": true
     },
     "onetime": {
       "version": "5.1.2",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "coincident-spectra",
   "version": "0.1.0",
   "scripts": {
-    "dev": "vite dev --port 3000",
+    "dev": "vite dev",
     "build": "vite build",
     "preview": "vite preview",
     "test": "ava src/**/*.test.ts",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     "eslint": "^7.32.0",
     "eslint-config-prettier": "^8.1.0",
     "eslint-plugin-svelte3": "^3.2.1",
-    "one-webcrypto": "^1.0.1",
     "prettier": "~2.2.1",
     "prettier-plugin-svelte": "^2.2.0",
     "rehype-autolink-headings": "^6.1.0",
@@ -41,8 +40,8 @@
   },
   "type": "module",
   "dependencies": {
-    "@elemaudio/core": "^1.0.5",
-    "@elemaudio/web-renderer-lite": "^1.0.0",
+    "@elemaudio/core": "^1.0.8",
+    "@elemaudio/web-renderer": "^1.0.16",
     "rxjs": "^7.5.4"
   },
   "ava": {

--- a/src/lib/audio/audio.ts
+++ b/src/lib/audio/audio.ts
@@ -2,7 +2,7 @@ import type { NodeRepr_t } from '@elemaudio/core'
 
 import { el } from '@elemaudio/core'
 import { get } from 'svelte/store'
-import WebRenderer from '@elemaudio/web-renderer-lite'
+import WebRenderer from '@elemaudio/web-renderer'
 
 import { additiveSynth } from '$lib/audio/additive-synth'
 import { tune } from '$lib/audio/tuning'

--- a/src/stores.ts
+++ b/src/stores.ts
@@ -2,7 +2,7 @@ import type { Writable } from 'svelte/store'
 import { writable } from 'svelte/store'
 
 import type { MidiStatus } from '$lib/controllers/midi'
-import type WebAudioRenderer from '@elemaudio/web-renderer-lite'
+import type WebAudioRenderer from '@elemaudio/web-renderer'
 
 type AudioStore = {
   context: AudioContext


### PR DESCRIPTION
# Description

This PR implements the following features:

- [x] Switch from `@elemaudio/web-renderer-lite` to `@elemaudio/web-renderer`.
- [x] Upgrade `@elemaudio/core`
- [x] Update npm `dev` script to use default port

## Type of change

- [x] Refactor (non-breaking change that updates existing functionality)

## Test plan (required)

The app should continue to work in local development, built, and published to Fission.
