### PR TITLE
Add Get Started modal

### DIFF
--- a/src/components/Controls.svelte
+++ b/src/components/Controls.svelte
@@ -3,44 +3,18 @@
   import type { NoteEventMap } from '$lib/controllers'
   import type { Synth } from '$lib/audio/audio'
 
-  import { audioStore } from '../stores'
   import Controller from '$components/controls/Controller.svelte'
   import Partials from '$components/controls/Partials.svelte'
   import Tuning from '$components/controls/Tuning.svelte'
 
   export let noteEmitter: EventEmitter<NoteEventMap>
   export let synth: Synth
-
-  const startAudio = () => {
-    synth.start(noteEmitter)
-  }
-
-  const pauseAudio = () => {
-    synth.pause(noteEmitter)
-  }
 </script>
 
 <div class="grid grid-flow-row auto-rows-max gap-7">
   <div class="grid grid-flow-col auto-cols-max gap-4">
-    {#if $audioStore.contextState === 'running'}
-      <button
-        class="btn btn-primary"
-        on:click={pauseAudio}
-        on:keypress={pauseAudio}
-      >
-        Pause Audio
-      </button>
-    {:else}
-      <button
-        class="btn btn-primary"
-        on:click={startAudio}
-        on:keypress={startAudio}
-      >
-        Start Audio
-      </button>
-    {/if}
     <Partials {synth} />
-    <Controller {noteEmitter} {synth} />
     <Tuning {synth} />
+    <Controller {noteEmitter} {synth} />
   </div>
 </div>

--- a/src/components/MoreInformation.svelte
+++ b/src/components/MoreInformation.svelte
@@ -1,47 +1,5 @@
 <div class="grid grid-flow-row auto-rows-max gap-6">
   <div class="grid grid-flow-row auto-rows-max gap-2">
-    <h2 class="text-2xl">Of Harmonics and Spectra</h2>
-    <p>
-      Coincident Spectra is an additive synthesizer that generates sounds from
-      16 sine wave 'partials' that can be switched between harmonics and
-      spectra. Harmonics are integer multiples of a fundamental frequency.
-      Spectra remap harmonics so that the partials coincide with a selected
-      equal temperament.
-    </p>
-    <p>
-      Coincident spectra reduce sensory dissonance and beating between the
-      timbre and tuning, rendering chords more in tune.
-    </p>
-  </div>
-  <div class="grid grid-flow-row auto-rows-max gap-2">
-    <h2 class="text-2xl">Listen and Compare</h2>
-    <ul class="list-disc list-inside">
-      <li>Select Start Audio to activate the instrument</li>
-      <li>Select Keyboard or a MIDI controller</li>
-      <li>Play notes and chords in Harmonics mode</li>
-      <li>Switch to Spectra mode while holding a chord. Listen and compare.</li>
-    </ul>
-    <p>
-      Play
-      <kbd class="kbd kbd-sm">u</kbd>,
-      <kbd class="kbd kbd-sm">[</kbd>, and
-      <kbd class="kbd kbd-sm">2</kbd>
-      in 12-tone equal temperament (12-TET) for a C-major chord on your computer
-      keyboard.
-    </p>
-    <p>
-      MIDI is available in Chrome and Chromium-based browsers, and it will
-      likely be available in Firefox soon.
-    </p>
-  </div>
-  <div class="grid grid-flow-row auto-rows-max gap-2">
-    <h2 class="text-2xl">Adjust Timbre</h2>
-    <p>
-      The gain sliders control the gain of each partial. Adjusting them
-      changes the timbre of the instrument.
-    </p>
-  </div>
-  <div class="grid grid-flow-row auto-rows-max gap-2">
     <h2 class="text-2xl">Acknowledgments</h2>
     <p>
       Coincident Spectra was inspired by the work of William Sethares. To find

--- a/src/components/controls/GetStarted.svelte
+++ b/src/components/controls/GetStarted.svelte
@@ -1,0 +1,76 @@
+<script lang="ts">
+  import type { EventEmitter } from '$lib/common/event-emitter'
+  import type { NoteEventMap } from '$lib/controllers'
+  import type { Synth } from '$lib/audio/audio'
+
+  export let noteEmitter: EventEmitter<NoteEventMap>
+  export let synth: Synth
+
+  let modalState: 'open' | 'closed' = 'open'
+
+  const getStarted = () => {
+    synth.start(noteEmitter)
+
+    modalState = 'closed'
+  }
+</script>
+
+<!--
+  The modal must be removed from the DOM to prevent it from
+  capturing keyboard events after the user has selected a tuning.
+-->
+{#if modalState === 'open'}
+  <!-- svelte-ignore a11y-autofocus -->
+  <div autofocus class="modal modal-open">
+    <div class="modal-box relative sm:w-5/6 md:w-full">
+      <div class="grid grid-flow-row auto-rows-max gap-4 w-full">
+        <div class="justify-center">
+          <h2 class="text-3xl">Coincident Spectra</h2>
+        </div>
+
+        <div class="grid grid-flow-row auto-rows-max gap-2">
+          <p>
+            Coincident Spectra is an additive synthesizer that generates sounds
+            from 16 sine wave 'partials' that can be switched between harmonics
+            and spectra. Harmonics are integer multiples of a fundamental
+            frequency. Spectra remap harmonics so that the partials coincide
+            with a selected equal temperament.
+          </p>
+          <p>
+            Coincident spectra reduce sensory dissonance and beating between the
+            timbre and tuning, rendering chords more in tune.
+          </p>
+        </div>
+
+        <div class="grid grid-flow-row auto-rows-max gap-2">
+          <h2 class="text-2xl">How to use</h2>
+          <p>
+            Play notes on your computer keyboard or MIDI controller. Select the
+            Keyboard button to switch controllers.
+          </p>
+          <p>
+            Select Harmonics or Spectra to change the partials mode. We
+            recommend holding a note or chord when changing the partials mode to
+            hear the difference.
+          </p>
+          <p>
+            Select the ED2-12 button to change the tuning system. The default
+            ED2-12 tuning system is 12-tone equal temperament.
+          </p>
+          <p>
+            Increase the gain of a partial to hear it individually. Adjust
+            partial gains to change the timbre of the instrument.
+          </p>
+        </div>
+
+        <button
+          class="btn btn-primary w-full"
+          on:click|self={getStarted}
+          on:keypress|self={getStarted}
+        >
+          Get Started
+        </button>
+      </div>
+    </div>
+  </div>
+{/if}

--- a/src/components/controls/GetStarted.svelte
+++ b/src/components/controls/GetStarted.svelte
@@ -3,15 +3,21 @@
   import type { NoteEventMap } from '$lib/controllers'
   import type { Synth } from '$lib/audio/audio'
 
+  import * as midi from '$lib/controllers/midi'
+
   export let noteEmitter: EventEmitter<NoteEventMap>
   export let synth: Synth
 
   let modalState: 'open' | 'closed' = 'open'
 
-  const getStarted = () => {
+  const getStarted = async () => {
     synth.start(noteEmitter)
 
     modalState = 'closed'
+
+    // The browser will request access to
+    // WebMIDI, so we close the modal first
+    await midi.initialize()
   }
 </script>
 

--- a/src/components/controls/Tuning.svelte
+++ b/src/components/controls/Tuning.svelte
@@ -73,8 +73,8 @@
           {/each}
           <p class="text-xs italic">
             ED2 stands for equal division of the second harmonic, which is the
-            octave. 12-ED2 is 12-tone equal temperament, where we divide the
-            octave into twelve equal parts.
+            octave. For example, 12-ED2 divides the octave into twelve equal
+            parts.
           </p>
         </div>
       </div>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -7,6 +7,7 @@
   import partialsData from '$lib/audio/partials.json'
   import { drawbars, partials, tuning } from '../stores'
   import Controls from '$components/Controls.svelte'
+  import GetStarted from '$components/controls/GetStarted.svelte'
   import Guide from '$components/Guide.svelte'
 
   type View = 'instrument' | 'info'
@@ -41,6 +42,8 @@
     synth.updateParams()
   }
 </script>
+
+<GetStarted {noteEmitter} {synth}/>
 
 <div
   class="grid grid-flow-row auto-rows-max justify-center bg-neutral h-screen p-10 text-base-content"

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -8,7 +8,7 @@
   import { drawbars, partials, tuning } from '../stores'
   import Controls from '$components/Controls.svelte'
   import GetStarted from '$components/controls/GetStarted.svelte'
-  import Guide from '$components/Guide.svelte'
+  import MoreInformation from '$components/MoreInformation.svelte'
 
   type View = 'instrument' | 'info'
 
@@ -43,7 +43,7 @@
   }
 </script>
 
-<GetStarted {noteEmitter} {synth}/>
+<GetStarted {noteEmitter} {synth} />
 
 <div
   class="grid grid-flow-row auto-rows-max justify-center bg-neutral h-screen p-10 text-base-content"
@@ -119,7 +119,7 @@
           </div>
         </div>
       {:else}
-        <Guide />
+        <MoreInformation />
       {/if}
     </div>
   </div>


### PR DESCRIPTION
# Description

This PR implements the following features:

- [x] Adds a Get Started modal
- [x] Removes the start and pause audio button
- [x] Removes guide text from the more information view
- [x] Updates the tuning system explainer text
- [x] Moves WebMidi initialization to the Get Started interface

## Link to issue

Closes #12 

## Type of change

- [x] New feature (non-breaking change that adds functionality)
- [x] Refactor (non-breaking change that updates existing functionality)

## Test plan (required)

Test that the modal displays on page load, and the "Get Started" button closes the modal and starts audio in the app.
